### PR TITLE
Turn off validation during deploy due to k8s version 1.15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ uninstall: manifests
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy:
 	cd config/manager && kustomize edit set image controller=${IMG}
-	kustomize build config/default | kubectl apply -f -
+	kustomize build config/default | kubectl apply --validate=false -f -
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #5 
| License         | Apache 2.0


### What's in this PR?
In the case of the k8s version 1.15 or below the CRD validation returns an error during `make deploy`