### PR TITLE
Use ghcr as default registry for analyzer image

### DIFF
--- a/pkg/k8sutil/service.go
+++ b/pkg/k8sutil/service.go
@@ -86,7 +86,7 @@ func GetServiceAnotations(service *corev1.Service, log logr.Logger) (map[string]
 		}
 		zaProxyCfg["analyzer_image"], ok = annotations["dast.security.banzaicloud.io/analyzer_image"]
 		if !ok {
-			zaProxyCfg["analyzer_image"] = "banzaicloud/dast-analyzer:latest"
+			zaProxyCfg["analyzer_image"] = "ghcr.io/banzaicloud/dast-analyzer:latest"
 			log.Info("missing zaproxy analyzer image annotation, using ", "analyzer_image", zaProxyCfg["analyzer_image"])
 		}
 		return zaProxyCfg, nil


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
In the case of analyzer image us `ghcr.io` as the default registry.