### PR TITLE
charts: bump image version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
     branches: [master,]
     paths-ignore:
       - 'README.md'
+      - 'charts/**'
 
 jobs:
 

--- a/charts/dast-operator/Chart.yaml
+++ b/charts/dast-operator/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.2.1
+appVersion: 0.3.0
 
 home: https://github.com/banzaicloud/dast-operator
 maintainers:


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | related: #14 
| License         | Apache 2.0


### What's in this PR?
Bump image version to 0.3.0 which contains the support of `networking.k8s.io/v1` API version.